### PR TITLE
Decode attached rfc822 messages if they are base64 encoded.

### DIFF
--- a/csirtg_mail/parse.py
+++ b/csirtg_mail/parse.py
@@ -120,6 +120,12 @@ def get_decoded_body(p, d):
 
     return d
 
+def get_transfer_encoding(headers):
+    return_value = None
+    for header_item in headers:
+        if header_item[0] == 'Content-Transfer-Encoding':
+            return_value = header_item[1]
+    return return_value
 
 def get_messages_as_attachments(message):
     results = []
@@ -134,7 +140,8 @@ def get_messages_as_attachments(message):
                     for attachment in attachments:
                         a = {
                             'type': z.get_content_type(),
-                            'attachment': str(attachment),
+                            'attachment': attachment.as_string(),
+                            'encoding': get_transfer_encoding(z._headers)
                         }
                         results.append(a)
     return results
@@ -226,7 +233,10 @@ def parse_attached_emails(attachments):
     flattened = []
     for a in attachments:
         if a['type'] == "message/rfc822":
-            d = parse_email_from_string(a['attachment'])
+            if a['encoding'] == 'base64':
+                d = parse_email_from_string(base64.b64decode(a['attachment']).decode()) 
+            else:    
+                d = parse_email_from_string(a['attachment'])
             flattened = flatten(d)
     return flattened
 


### PR DESCRIPTION
In some cases when Content-Transfer-Encoding is set to base64, an attached rfc822 message was not being decoded prior to being passed to parse_email_from_string.  

The test cases only handle the case where 7bit clean messages are sent as attachments.

