### PR TITLE
Spaces in URLs and emails in mailto links

### DIFF
--- a/csirtg_mail/parse.py
+++ b/csirtg_mail/parse.py
@@ -120,12 +120,14 @@ def get_decoded_body(p, d):
 
     return d
 
+
 def get_transfer_encoding(headers):
     return_value = None
     for header_item in headers:
         if header_item[0] == 'Content-Transfer-Encoding':
             return_value = header_item[1]
     return return_value
+
 
 def get_messages_as_attachments(message):
     results = []
@@ -197,10 +199,12 @@ def extract_urls(mail_parts, defanged_urls=False):
     for mail_part in mail_parts:
         if mail_part['is_body']:
             if mail_part['is_body'].startswith('text/html'):
-                l = _extract_urls(mail_part['decoded_body'], html=True, defanged_urls=defanged_urls)
+                l = _extract_urls(
+                    mail_part['decoded_body'], html=True, defanged_urls=defanged_urls)
                 links.update(l)
             if mail_part['is_body'].startswith('text/plain'):
-                l = _extract_urls(mail_part['decoded_body'], html=False, defanged_urls=defanged_urls)
+                l = _extract_urls(
+                    mail_part['decoded_body'], html=False, defanged_urls=defanged_urls)
                 links.update(l)
 
     return list(links)
@@ -212,10 +216,12 @@ def extract_email_addresses(mail_parts):
     for mail_part in mail_parts:
         if mail_part['is_body']:
             if mail_part['is_body'].startswith('text/html'):
-                email_address = _extract_email_addresses(mail_part['decoded_body'], html=True)
+                email_address = _extract_email_addresses(
+                    mail_part['decoded_body'], html=True)
                 email_addresses.update(email_address)
             if mail_part['is_body'].startswith('text/plain'):
-                email_address = _extract_email_addresses(mail_part['decoded_body'], html=False)
+                email_address = _extract_email_addresses(
+                    mail_part['decoded_body'], html=False)
                 email_addresses.update(email_address)
 
     return list(email_addresses)
@@ -234,8 +240,9 @@ def parse_attached_emails(attachments):
     for a in attachments:
         if a['type'] == "message/rfc822":
             if a['encoding'] == 'base64':
-                d = parse_email_from_string(base64.b64decode(a['attachment']).decode()) 
-            else:    
+                d = parse_email_from_string(
+                    base64.b64decode(a['attachment']).decode())
+            else:
                 d = parse_email_from_string(a['attachment'])
             flattened = flatten(d)
     return flattened
@@ -262,7 +269,8 @@ def parse_email_from_string(email, defanged_urls=False):
     d['urls'] = urls = extract_urls(mail_parts, defanged_urls=defanged_urls)
 
     # get email addresses from message body
-    d['body_email_addresses'] = email_addresses = extract_email_addresses(mail_parts)
+    d['body_email_addresses'] = email_addresses = extract_email_addresses(
+        mail_parts)
 
     # find encapsulated emails in attachments
     attached_emails = parse_attached_emails(attachments)
@@ -272,6 +280,7 @@ def parse_email_from_string(email, defanged_urls=False):
     results.append(d)
 
     return results
+
 
 # testing- use functions above
 from .utils import parse_headers
@@ -300,14 +309,14 @@ def from_string(data):
 
     # is fwd
 
-    ## inline
-    ## attachment is .eml
-    ## is html
-    ## is txt
-    ## attachment is [.docx?|.zip|.html?|.xlsx?]
-    ## multiple .eml attachments
-    ## is html
-    ## is txt
+    # inline
+    # attachment is .eml
+    # is html
+    # is txt
+    # attachment is [.docx?|.zip|.html?|.xlsx?]
+    # multiple .eml attachments
+    # is html
+    # is txt
 
     urls = set()
     email_addresses = set()

--- a/csirtg_mail/urls.py
+++ b/csirtg_mail/urls.py
@@ -9,7 +9,7 @@ except ImportError:
 from pprint import pprint
 
 RE_URL_PLAIN = r'(https?://[^\s>|^\"]+)'
-RE_URL_DEFANGED = r'(hxxps?://[^\s>]+)'
+RE_URL_DEFANGED = r'((?:hxxps?:\/\/.*?(?=\/))(?:.*?(?=\s)))'
 RE_IPV4 = re.compile(
     '^(.+:.+@)?(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:\d+)?$')
 # http://stackoverflow.com/a/17871737
@@ -115,6 +115,10 @@ def _extract_urls_text(content, defanged_urls=False):
             re.findall(RE_URL_PLAIN, content, re.MULTILINE)
 
     for u in found:
+        u = u.replace(" ", "")
+        if defanged_urls:
+            urls.add(u)
+        else:
         if _url(u):
             urls.add(u)
 

--- a/csirtg_mail/urls.py
+++ b/csirtg_mail/urls.py
@@ -19,7 +19,7 @@ RE_FQDN = re.compile(
     '^(.+:.+@)?((xn--)?(--)?[a-zA-Z0-9-_]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}(--p1ai)?(:\d+)?$')
 RE_URI_SCHEMES = re.compile('^(https?|hxxps?|ftp)$')
 RE_EMAIL_ADDRESS = re.compile(
-    '([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)')
+    '(?:%\w\w)?([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)')
 
 
 def _extract_email_addresses_text(content):
@@ -48,8 +48,19 @@ def _extract_email_addresses_html(content):
 
     soup = BeautifulSoup(content, "lxml")
 
-    email_addresses = re.findall(
+    # Look in anchor links for email addresses - common with mailto:
+    for link in soup.find_all("a"):
+        found = re.findall(
+            RE_EMAIL_ADDRESS, str(link))
+        for address in found:
+            email_addresses.add(address)
+
+    # look in the text of the email
+    found = re.findall(
         RE_EMAIL_ADDRESS, soup.get_text(separator=' '))
+
+    for address in found:
+        email_addresses.add(address)
 
     return email_addresses
 
@@ -119,8 +130,8 @@ def _extract_urls_text(content, defanged_urls=False):
         if defanged_urls:
             urls.add(u)
         else:
-        if _url(u):
-            urls.add(u)
+            if _url(u):
+                urls.add(u)
 
     return urls
 

--- a/samples/email/single_html_05.eml
+++ b/samples/email/single_html_05.eml
@@ -1,0 +1,28 @@
+Delivered-To: phish@csirtgadgets.org
+Received: by 10.112.40.50 with SMTP id u18csp916705lbk;
+        Sun, 19 Apr 2015 05:50:04 -0700 (PDT)
+X-Received: by 10.42.151.4 with SMTP id c4mr13784232icw.77.1429447803846;
+        Sun, 19 Apr 2015 05:50:03 -0700 (PDT)
+Return-Path: <advertisebz09ua@gmail.com>
+Received: from gmail.com ([61.72.137.254])
+        by mx.google.com with SMTP id s93si13575887ioe.52.2015.04.19.05.50.00
+        for <phish@csirtgadgets.org>;
+        Sun, 19 Apr 2015 05:50:03 -0700 (PDT)
+Received-SPF: softfail (google.com: domain of transitioning advertisebz09ua@gmail.com does not designate 61.72.137.254 as permitted sender) client-ip=61.72.137.254;
+Authentication-Results: mx.google.com;
+       spf=softfail (google.com: domain of transitioning advertisebz09ua@gmail.com does not designate 61.72.137.254 as permitted sender) smtp.mail=advertisebz09ua@gmail.com;
+       dmarc=fail (p=NONE dis=NONE) header.from=gmail.com
+Message-ID: <BE5B7E8D.883B43A2@gmail.com>
+Date: Sun, 19 Apr 2015 05:24:33 -0700
+Reply-To: "HENRY" <advertisebz09ua@gmail.com>
+From: "HENRY" <advertisebz09ua@gmail.com>
+User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.8.1.19) Gecko/20081209 Thunderbird/2.0.0.19
+MIME-Version: 1.0
+To: <phish@csirtgadgets.org>
+Subject: Attention Please!!!
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<span>&nbsp;</span><br>
+<span>Attention Please!!!<br /><br />I have registered your ATM CARD of $2.5usd with DHL Courier Company with Package Number: 0022755. please Contact with your delivery information such as, Your Name, Your Address and Your Telephone Number: DHL Office <br /><br />Name of Mr.FRANK JOE<br />E-mail: (<a href="mailto:ebay%3Cuser1@example.com%3E,%3Cuser2@example.com%3E">Click here</a>)<br />Tel:+229)68-68-63-43<br /><br />I have paid for the Insurance &amp; Delivery fee.The only fee you have to pay is their Security fee $55.Please indicate the registration Number and ask Him how to pay their Security fee so that you can pay it immediately.<br /><br />Best Regards,<br />Faye Lucas</span><br>

--- a/samples/email/single_plain_05.eml
+++ b/samples/email/single_plain_05.eml
@@ -1,0 +1,46 @@
+Delivered-To: phish@csirtgadgets.org
+Received: by 10.112.40.50 with SMTP id u18csp916705lbk;
+        Sun, 19 Apr 2015 05:50:04 -0700 (PDT)
+X-Received: by 10.42.151.4 with SMTP id c4mr13784232icw.77.1429447803846;
+        Sun, 19 Apr 2015 05:50:03 -0700 (PDT)
+Return-Path: <advertisebz09ua@gmail.com>
+Received: from gmail.com ([61.72.137.254])
+        by mx.google.com with SMTP id s93si13575887ioe.52.2015.04.19.05.50.00
+        for <phish@csirtgadgets.org>;
+        Sun, 19 Apr 2015 05:50:03 -0700 (PDT)
+Received-SPF: softfail (google.com: domain of transitioning advertisebz09ua@gmail.com does not designate 61.72.137.254 as permitted sender) client-ip=61.72.137.254;
+Authentication-Results: mx.google.com;
+       spf=softfail (google.com: domain of transitioning advertisebz09ua@gmail.com does not designate 61.72.137.254 as permitted sender) smtp.mail=advertisebz09ua@gmail.com;
+       dmarc=fail (p=NONE dis=NONE) header.from=gmail.com
+Message-ID: <BE5B7E8D.883B43A2@gmail.com>
+Date: Sun, 19 Apr 2015 05:24:33 -0700
+Reply-To: "HENRY" <advertisebz09ua@gmail.com>
+From: "HENRY" <advertisebz09ua@gmail.com>
+User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.8.1.19) Gecko/20081209 Thunderbird/2.0.0.19
+MIME-Version: 1.0
+To: <phish@csirtgadgets.org>
+Subject: Boost Social Presence with FB posts likes
+Content-Type: text/plain;
+    charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+
+
+Please find the details of the following new Phishing incident:
+
+----------------------
+URL: hxxps://www .blah .blah .com .badness .com /badness.php Brand Targeted: Awesome stuff
+
+Web Host:
+Web Host Country:
+
+
+Please find the details of the following new Phishing incident:
+
+----------------------
+URL: hxxp://www .blah .blah .com .badness .com /wp=stuff/uno/dos/tres/
+Brand Targeted: Awesome stuff
+
+Web Host:
+Web Host Country:
+
+

--- a/test/test_single_html_05.py
+++ b/test/test_single_html_05.py
@@ -1,0 +1,23 @@
+import csirtg_mail
+from csirtg_mail.constants import PYVERSION
+
+TEST_FILE = 'samples/email/single_html_05.eml'
+
+if PYVERSION > 2:
+    with open(TEST_FILE, encoding='latin-1') as f:
+        email = f.read()
+        email = str(email)
+else:
+    with open(TEST_FILE) as f:
+        email = f.read()
+
+results = csirtg_mail.parse_email_from_string(email)
+
+
+def test_message_headers():
+    assert results[0]['headers']['return-path'][0] == '<advertisebz09ua@gmail.com>'
+
+
+def test_body_email_addresses():
+    assert "user1@example.com" in results[0]['body_email_addresses']
+    assert "user2@example.com" in results[0]['body_email_addresses']

--- a/test/test_single_plain_05.py
+++ b/test/test_single_plain_05.py
@@ -1,0 +1,17 @@
+import csirtg_mail
+
+TEST_FILE = 'samples/email/single_plain_05.eml'
+
+with open(TEST_FILE) as f:
+    email = f.read()
+
+results = csirtg_mail.parse_email_from_string(email, defanged_urls=True)
+
+
+def test_message_headers():
+    assert results[0]['headers']['return-path'][0] == '<advertisebz09ua@gmail.com>'
+
+
+def test_extract_urls():
+    print(results[0]['urls'])
+    assert "hxxp://www.blah.blah.com.badness.com/wp=stuff/uno/dos/tres/" in results[0]['urls']


### PR DESCRIPTION
These changes handle adding two use cases we are seeing then trying to parse reported phishing emails.
One is around an organisation using 'spaces' to defang a url in the fqdn portion.  
The other is around email addresses in mailto: urls not being parsed due to the soup.get_text call not returning these.  This also required the email RE to be tweeked to ignore any URL encoding chars to be ignored if they are at the front of an email address.
Eg Bob<bob@bob.com>  would turn into Bob%3Cbob@bob.com%3E and return 3Cbob@bob.com as the parsed email address.