### PR TITLE
Install different version of pyzmail depending on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyzmail>=1.0.3,<2.0
+#pyzmail>=1.0.3,<2.0
 beautifulsoup4>=4.4.0
 chardet>=2.3.0
 lxml>=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,24 @@ cmds = [
     'csirtg-mail=csirtg_mail.client:main'
 ]
 
+
+def get_requirements_by_version():
+    base_packages = [
+        'beautifulsoup4',
+        'chardet',
+        'lxml',
+        'html5lib'
+    ]
+
+    packages27 = ['pyzmail']
+    packages36 = ['pyzmail36']
+
+    if sys.version_info.major >= (3) and sys.version_info.minor >= (6):
+        return base_packages + packages36
+    else:
+        return base_packages + packages27
+
+
 setup(
     name="csirtg_mail",
     version=versioneer.get_version(),
@@ -42,23 +60,17 @@ setup(
     url="https://github.com/csirtgadgets/csirtg-mail-py",
     license='MPL2',
     classifiers=[
-               "Topic :: System :: Networking",
-               "Environment :: Other Environment",
-               "Intended Audience :: Developers",
-               "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-               "Programming Language :: Python",
-               ],
+        "Topic :: System :: Networking",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+        "Programming Language :: Python",
+    ],
     keywords=['security'],
     author="Wes Young",
     author_email="wes@csirtgadgets.org",
     packages=find_packages(),
-    install_requires=[
-        'beautifulsoup4',
-        'pyzmail',
-        'chardet',
-        'lxml',
-        'html5lib'
-    ],
+    install_requires=get_requirements_by_version(),
     entry_points={
         'console_scripts': cmds
     },


### PR DESCRIPTION
We were having issues installing csirtg-mail on ubuntu bionic.  It installs on ubuntu xenial just fine.
Turns out that pyzmail has issues on python 3.6 or greater.

There's another version of pyzmail (pyzmail36) which solves this. 

These are some changes to the setup.py to install the appropriate library depending on the version of python.