### PR TITLE
Added feature to sanitize URLs

### DIFF
--- a/csirtg_mail/client.py
+++ b/csirtg_mail/client.py
@@ -31,6 +31,7 @@ def main():
 
     p.add_argument("-f", "--file", dest="file", help="specify email file")
     p.add_argument("-d", "--debug", help="enable debugging", action="store_true")
+    p.add_argument("-s", "--sanitize", help="strip parameters (...?foo=bar) from parsed URLs", action="store_true")
     p.add_argument("--urls", help="print URLS to stdout", action="store_true")
 
     args = p.parse_args()
@@ -54,7 +55,7 @@ def main():
         email = sys.stdin.read()
 
     # parse email message
-    results = parse_email_from_string(email)
+    results = parse_email_from_string(email, sanitize_urls=options.get("sanitize"))
 
     if args.urls:
         for e in results:

--- a/csirtg_mail/parse.py
+++ b/csirtg_mail/parse.py
@@ -193,7 +193,7 @@ def parse_message_parts(message_parts):
     return mail_parts
 
 
-def extract_urls(mail_parts, defanged_urls=False):
+def extract_urls(mail_parts, defanged_urls=False, sanitize_urls=False):
     links = set()
 
     # results = parse_email_from_string(email)
@@ -202,11 +202,11 @@ def extract_urls(mail_parts, defanged_urls=False):
         if mail_part['is_body']:
             if mail_part['is_body'].startswith('text/html'):
                 l = _extract_urls(
-                    mail_part['decoded_body'], html=True, defanged_urls=defanged_urls)
+                    mail_part['decoded_body'], html=True, defanged_urls=defanged_urls, sanitize_urls=sanitize_urls)
                 links.update(l)
             if mail_part['is_body'].startswith('text/plain'):
                 l = _extract_urls(
-                    mail_part['decoded_body'], html=False, defanged_urls=defanged_urls)
+                    mail_part['decoded_body'], html=False, defanged_urls=defanged_urls, sanitize_urls=sanitize_urls)
                 links.update(l)
 
     return list(links)
@@ -265,7 +265,8 @@ def parse_attached_emails(attachments):
     return flattened
 
 
-def parse_email_from_string(email, defanged_urls=False):
+def parse_email_from_string(email, defanged_urls=False, sanitize_urls=False):
+
     results = []
 
     d = {}
@@ -283,7 +284,7 @@ def parse_email_from_string(email, defanged_urls=False):
     attachments = get_messages_as_attachments(message)
 
     # get urls from message body
-    d['urls'] = urls = extract_urls(mail_parts, defanged_urls=defanged_urls)
+    d['urls'] = urls = extract_urls(mail_parts, defanged_urls=defanged_urls, sanitize_urls=sanitize_urls)
 
     # get BTC addresses from message body
     d['btcs'] = btcs = extract_btcs(mail_parts)

--- a/csirtg_mail/urls.py
+++ b/csirtg_mail/urls.py
@@ -156,7 +156,7 @@ def _extract_urls_html(body, defanged_urls=False, images=False):
     return urls
 
 
-def extract_urls(content, html=False, defanged_urls=False):
+def extract_urls(content, html=False, defanged_urls=False, sanitize_urls=False):
     urls = set()
 
     from .constants import PYVERSION
@@ -169,6 +169,16 @@ def extract_urls(content, html=False, defanged_urls=False):
             urls = _extract_urls_html(content, defanged_urls=defanged_urls)
         else:
             urls = _extract_urls_text(content, defanged_urls=defanged_urls)
+
+        # check do we want to strip parameters from URLs, i.e. remove '?foo=bar'
+        if sanitize_urls:
+            sanitized_urls = set()
+            for url in urls:
+                if '?' in url: # if this URL has parameters
+                    param_start = url.index('?')
+                    s_url = url[:param_start]
+                    sanitized_urls.add(s_url) # Add the sanitized URL to the sanitized set
+            urls = sanitized_urls # replace the set we are returning with the sanitized set
     else:
         return urls
 

--- a/test/test_single_html_02_sanitized_urls.py
+++ b/test/test_single_html_02_sanitized_urls.py
@@ -1,0 +1,21 @@
+import csirtg_mail
+
+TEST_FILE = 'samples/email/single_html_02.eml'
+
+with open(TEST_FILE) as f:
+    email = f.read()
+
+results = csirtg_mail.parse_email_from_string(email, sanitize_urls=True)
+
+
+def test_message_headers():
+    assert results[0]['headers']['return-path'][0] == 'Appidms@tripadvisor.com'
+
+
+def test_message_parts():
+    assert results[0]['mail_parts'][0]['decoded_body'].startswith('<HTML>\n<div id=":219" class="zz J-J5-Ji">')
+
+
+def test_extract_urls():
+    assert "http://www.homerunsports.com/sites/all/themes/zen/zen-internals/css/direct/index.php" in results[0]['urls']
+


### PR DESCRIPTION
I added a feature in my fork to sanitize URLs by removing parameters. For example, "http://example.com/path/function.php?foo=bar" becomes "http://example.com/path/function.php" with sanitation enabled. If this is still a desired feature in csirtg-mail-py, let me know if there is anything I should change in my PR.