### PR TITLE
Bug Fixes

### DIFF
--- a/csirtg_mail/client.py
+++ b/csirtg_mail/client.py
@@ -30,8 +30,10 @@ def main():
     )
 
     p.add_argument("-f", "--file", dest="file", help="specify email file")
-    p.add_argument("-d", "--debug", help="enable debugging", action="store_true")
-    p.add_argument("-s", "--sanitize", help="strip parameters (...?foo=bar) from parsed URLs", action="store_true")
+    p.add_argument("-d", "--debug", help="enable debugging",
+                   action="store_true")
+    p.add_argument("-s", "--sanitize",
+                   help="strip parameters (...?foo=bar) from parsed URLs", action="store_true")
     p.add_argument("--urls", help="print URLS to stdout", action="store_true")
 
     args = p.parse_args()
@@ -49,13 +51,14 @@ def main():
 
     # get email from file or stdin
     if options.get("file"):
-        with open(options["file"]) as f:
+        with open(options["file"],  errors='ignore') as f:
             email = f.read()
     else:
         email = sys.stdin.read()
 
     # parse email message
-    results = parse_email_from_string(email, sanitize_urls=options.get("sanitize"))
+    results = parse_email_from_string(
+        email, sanitize_urls=options.get("sanitize"))
 
     if args.urls:
         for e in results:

--- a/csirtg_mail/parse.py
+++ b/csirtg_mail/parse.py
@@ -161,14 +161,18 @@ def process_part_type(p, d):
         elif p.type == 'text/plain' or p.type == 'text/html' and p.disposition == 'inline':
             d = get_decoded_body(p, d)
         elif p.type.startswith('application'):
-            d['base64_encoded_payload'] = base64.b64encode(p.get_payload())
+            d['base64_encoded_payload'] = base64.b64encode(
+                p.get_payload()).decode('utf-8')
         elif p.type.startswith('image'):
-            d['base64_encoded_payload'] = base64.b64encode(p.get_payload())
+            d['base64_encoded_payload'] = base64.b64encode(
+                p.get_payload()).decode('utf-8')
     else:
         if p.type.startswith('application'):
-            d['base64_encoded_payload'] = base64.b64encode(p.get_payload())
+            d['base64_encoded_payload'] = base64.b64encode(
+                p.get_payload()).decode('utf-8')
         elif p.disposition == 'attachment':
-            d['base64_encoded_payload'] = base64.b64encode(p.get_payload())
+            d['base64_encoded_payload'] = base64.b64encode(
+                p.get_payload()).decode('utf-8')
     return d
 
 

--- a/test/test_multi_mixed_plain_application_x_zip_compressed_01.py
+++ b/test/test_multi_mixed_plain_application_x_zip_compressed_01.py
@@ -20,5 +20,5 @@ def test_message_headers():
 def test_message_parts():
     assert results[0]['mail_parts'][0]['decoded_body'].startswith(
         'See the attached zip file')
-    assert results[0]['mail_parts'][1]['base64_encoded_payload'].decode(
-        'utf-8').startswith('UEsDBBQACAAIAO')
+    assert results[0]['mail_parts'][1]['base64_encoded_payload'].startswith(
+        'UEsDBBQACAAIAO')


### PR DESCRIPTION
Hi there.
In testing we discovered and fixed two bugs.  

1. Certain bytes in windows-1252 encoded email can cause exceptions on reading in the email.  Adding errors='ignore' to the open command ensures that at least the rest of the email can be processed.
2. There were some attachments (such as those which were application/octet-stream encoded) which resulted in a bytes like object being included in the message parts tree.  When JSON serialisation of the tree was attempted this caused failures.  As the attachments are being base64 encoded there is no need for these to be bytes like objects and a .decode('utf-8') has been added to the end of those lines to turn them back into strings which can be JSON serialised.

Would it be possible to get a new release cut after these changes are merged so we can swing back to pulling from the upstream repo.

Thanks heaps
Dean